### PR TITLE
Fix scanner shutdown and db retries

### DIFF
--- a/run_extreme_parallel.sh
+++ b/run_extreme_parallel.sh
@@ -18,7 +18,9 @@ print_status() {
 start_hp_container() {
     local mount_path=$1
     local mount_name=$2
-    local container_name="nas-hp-${mount_name}"
+    # Sanitize container name to avoid invalid characters
+    local safe_name=$(echo "$mount_name" | tr -c 'a-zA-Z0-9_.-' '_')
+    local container_name="nas-hp-${safe_name}"
     
     print_status "Starting high-performance scan of $mount_name"
     
@@ -83,7 +85,6 @@ main() {
     done
     
     print_status "Found ${#MOUNTS[@]} mounts to scan"
-    # INSERT_YOUR_CODE
     read -p "Proceed with scanning? (y to continue, anything else to quit): " confirm
     if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
         echo "Aborted by user."


### PR DESCRIPTION
## Summary
- add retry loops for DB operations
- lazily generate directories during scan
- terminate worker pool on shutdown
- sanitize container names in runner script
- remove leftover placeholder

## Testing
- `python -m py_compile nas_scanner_hp.py`
- `shellcheck run_extreme_parallel.sh`

------
https://chatgpt.com/codex/tasks/task_e_687bf86e8ce08323a479ad332a1d0e89