### PR TITLE
Fix progress reporting f-string syntax

### DIFF
--- a/run_extreme_parallel.sh
+++ b/run_extreme_parallel.sh
@@ -149,7 +149,7 @@ for mount, files, gb in cursor.fetchall():
     total_files += files
     total_gb += gb
 print('-' * 50)
-print(f'{'TOTAL':20} {total_files:>10,} files  {total_gb:>8.1f} GB')
+print(f'{"TOTAL":20} {total_files:>10,} files  {total_gb:>8.1f} GB')
 "
         
         sleep 5


### PR DESCRIPTION
## Summary
- fix quoting for `TOTAL` progress output in `run_extreme_parallel.sh`

## Testing
- `bash -n run_extreme_parallel.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c253173948323972882965e8a4e75