### PR TITLE
Improve monitoring scripts and add smart scan monitor

### DIFF
--- a/shared/diagnose_now.sh
+++ b/shared/diagnose_now.sh
@@ -6,7 +6,8 @@ echo "Time: $(date)"
 echo ""
 
 echo "DATABASE STATUS:"
-DB_PATH="/mnt/database/nas_catalog.db"
+DB_PATH="/mnt/user/appdata/nas-scanner/scan_data/nas_catalog.db"
+[ -f "$DB_PATH" ] || DB_PATH="/mnt/user/appdata/nas-scanner-smart/smart_catalog.db"
 if [ -f "$DB_PATH" ]; then
     echo "Database size: $(du -h "$DB_PATH" | cut -f1)"
     echo "Last modified: $(stat -c %y "$DB_PATH")"

--- a/shared/monitor_db_activity.sh
+++ b/shared/monitor_db_activity.sh
@@ -2,10 +2,15 @@
 # monitor_db_activity.sh - Monitor database writes per second and show last 5 entries
 
 DB_PATH=${1:-/mnt/user/appdata/nas-scanner/scan_data/nas_catalog.db}
-
 if [ ! -f "$DB_PATH" ]; then
-    echo "Database not found at $DB_PATH"
-    exit 1
+    ALT_DB="/mnt/user/appdata/nas-scanner-smart/smart_catalog.db"
+    if [ -f "$ALT_DB" ]; then
+        echo "Database not found at $DB_PATH, using $ALT_DB"
+        DB_PATH="$ALT_DB"
+    else
+        echo "Database not found at $DB_PATH"
+        exit 1
+    fi
 fi
 
 prev_count=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM files" 2>/dev/null || echo 0)

--- a/shared/monitor_smart_scan.sh
+++ b/shared/monitor_smart_scan.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# monitor_smart_scan.sh - Monitor smart scanner progress
+
+SMART_DIR="/mnt/user/appdata/nas-scanner"
+DB_PATH="$SMART_DIR/smart_catalog.db"
+SMART_IMAGE="nas-scanner-smart:latest"
+
+if [ -n "$1" ]; then
+    DB_PATH="$1"
+fi
+
+while true; do
+    clear
+    echo "=== SMART SCANNER MONITOR ==="
+    echo "Time: $(date)"
+    echo
+
+    echo "Controller container(s):"
+    docker ps --filter "ancestor=$SMART_IMAGE" --format "table {{.Names}}\t{{.Status}}\t{{.RunningFor}}" || true
+    echo
+
+    echo "Worker containers:"
+    docker ps --filter "name=smart-scan-" --format "table {{.Names}}\t{{.Status}}\t{{.RunningFor}}"
+    echo
+
+    workers=$(docker ps --filter "name=smart-scan-" -q)
+    if [ -n "$workers" ]; then
+        docker stats --no-stream --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}" $workers
+    else
+        echo "No smart-scan worker containers running"
+    fi
+    echo
+
+    if [ -f "$DB_PATH" ]; then
+        echo "Database: $DB_PATH"
+        sqlite3 "$DB_PATH" "SELECT COUNT(*), printf('%.2f', SUM(size)/1024.0/1024.0/1024.0) FROM files" 2>/dev/null |
+            awk '{printf "Files: %s\nTotal GB: %s\n", $1, $2}'
+    else
+        echo "Database not found at $DB_PATH"
+    fi
+
+    echo
+    echo "Refresh in 5 seconds (Ctrl+C to exit)"
+    sleep 5
+done

--- a/shared/run_full_diagnostics.sh
+++ b/shared/run_full_diagnostics.sh
@@ -5,15 +5,20 @@ echo "Time: $(date)"
 echo ""
 
 echo "CONTAINER STATUS:"
-docker ps --filter "name=nas-hp-" --format "table {{.Names}}\t{{.Status}}\t{{.RunningFor}}"
+docker ps --filter "name=nas-hp-" --filter "name=smart-scan-" --format "table {{.Names}}\t{{.Status}}\t{{.RunningFor}}"
 echo ""
 
 echo "CONTAINER CPU/MEMORY (last 10 seconds):"
-docker stats --no-stream $(docker ps --filter "name=nas-hp-" -q) 2>/dev/null
+containers=$(docker ps --filter "name=nas-hp-" --filter "name=smart-scan-" -q)
+if [ -n "$containers" ]; then
+docker stats --no-stream $containers 2>/dev/null
+else
+echo "No containers running"
+fi
 echo ""
 
 echo "RECENT CONTAINER LOGS (last 3 lines each):"
-docker ps --filter "name=nas-hp-" --format "{{.Names}}" | while read container; do
+docker ps --filter "name=nas-hp-" --filter "name=smart-scan-" --format "{{.Names}}" | while read container; do
     echo "--- $container ---"
     docker logs --tail 3 "$container" 2>&1 | sed 's/^/  /'
 done


### PR DESCRIPTION
## Summary
- fix monitoring scripts to handle smart-scan container names
- fallback to smart scanner DB when monolithic DB missing
- adjust diagnostics script DB path
- add new `monitor_smart_scan.sh` helper

## Testing
- `bash test/run_tests.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d5de0986c832398f7f625b54d3398